### PR TITLE
Fix kubeconfig path resolution and put installation first in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ Then either **leave the Kubeconfig Path field empty** (the file is found automat
 
 #### Default search order (empty path)
 
-1. Every path listed in the `KUBECONFIG` environment variable
-2. `<config dir>/.kube/` then `<config dir>/` — e.g. `/config/.kube/`, `/config/`
-3. `~/.kube/` then `~/`
-4. `/config/.kube/`, `/config/`, `/root/.kube/`
+1. The `KUBECONFIG` environment variable — if it names any existing file, **all** of its entries are used and merged, so a split cluster/credentials setup keeps working
+2. The Home Assistant config directory: `.kube/` inside it, then the directory itself — e.g. `/config/.kube/`, then `/config/`
+3. `~/.kube/`, then `~/`
+4. `/config/.kube/`, `/config/`, `/root/.kube/`, `/root/` — skipped where they repeat the config directory from step 2
 
-In each directory the first match of `config`, `kubeconfig`, `kubeconfig.yaml`, or `kubeconfig.yml` is used.
+In each directory the first match of `config`, `kubeconfig`, `kubeconfig.yaml`, or `kubeconfig.yml` is used. The chosen file is written to the debug log.
 
 #### Kubeconfig requirements
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,174 @@
 
 A custom Home Assistant integration that monitors **FluxCD resources in Kubernetes** using **kubernetes-asyncio**. It exposes FluxCD resource status as Home Assistant sensor entities, each appearing as its own top-level device in the HA device registry.
 
-## Companion Lovelace Card
+## Contents
 
-The [**fluxcd-topology-card**](https://github.com/dawg-io/fluxcd-topology-card) is an optional companion custom card for Home Assistant dashboards. It visualizes the relationships between FluxCD resources (GitRepositories, HelmRepositories, HelmCharts, HelmReleases, Kustomizations, and more) as an interactive topology graph directly in your Lovelace UI.
+- [Installation](#installation)
+  - [Before you start](#before-you-start)
+  - [Step 1 — Install the integration](#step-1--install-the-integration)
+  - [Step 2 — Choose how Home Assistant reaches your cluster](#step-2--choose-how-home-assistant-reaches-your-cluster)
+  - [Step 3 — Apply the Kubernetes RBAC](#step-3--apply-the-kubernetes-rbac)
+  - [Step 4 — Add the integration in Home Assistant](#step-4--add-the-integration-in-home-assistant)
+  - [Troubleshooting](#troubleshooting)
+- [Features](#features)
+- [Companion Lovelace Card](#companion-lovelace-card)
+- [Resource Categories](#resource-categories)
+- [Sensor States](#sensor-states)
+- [Entity Attributes and Diagnostic Sensors](#entity-attributes-and-diagnostic-sensors)
+- [How It Works](#how-it-works)
+- [Lovelace Dashboard Examples](#lovelace-dashboard-examples)
+- [Project Structure](#project-structure)
+- [License](#license)
 
-It is built to work alongside this integration and enhances the monitoring experience by providing a graphical overview of your FluxCD resource dependencies — but it is entirely optional and not required for this integration to function.
+---
 
-Repository: [fluxcd-topology-card on GitHub](https://github.com/dawg-io/fluxcd-topology-card)
+## Installation
+
+### Before you start
+
+| Requirement | Notes |
+|---|---|
+| Home Assistant 2024.9.1 or newer | Any install type (OS, Container, Supervised, Core) |
+| Python 3.11+ | Already bundled with supported Home Assistant versions |
+| A Kubernetes cluster running FluxCD | Flux v2 CRDs; the Flux Operator is optional |
+| Network access to the Kubernetes API server | From the machine running Home Assistant |
+| `kubernetes-asyncio` | Installed automatically by Home Assistant |
+
+### Step 1 — Install the integration
+
+#### HACS (recommended)
+
+1. In HACS, open the three-dot menu → **Custom repositories**
+2. Add this repository with the category **Integration**
+3. Search for **FluxCD** in HACS and install it
+4. Restart Home Assistant
+
+#### Manual
+
+1. Copy the `custom_components/fluxcd_k8s` directory into your Home Assistant `custom_components` directory (next to `configuration.yaml`):
+   ```bash
+   cp -r custom_components/fluxcd_k8s /path/to/homeassistant/custom_components/
+   ```
+2. Restart Home Assistant
+
+### Step 2 — Choose how Home Assistant reaches your cluster
+
+| Access mode | Use when | What you need |
+|---|---|---|
+| **In-Cluster** | Home Assistant runs as a pod inside the cluster | Nothing — the pod's service account is used automatically |
+| **Kubeconfig File** | Home Assistant runs outside the cluster (HA OS, Container, Supervised, Core) | A kubeconfig file that Home Assistant can read |
+
+**In-Cluster** mode needs no further file setup — skip to [Step 3](#step-3--apply-the-kubernetes-rbac).
+
+#### Where to put the kubeconfig file
+
+Copy your kubeconfig into the Home Assistant **config directory** (the folder that holds `configuration.yaml`, usually `/config`) and name it `kubeconfig`:
+
+```bash
+# Docker / HA Container install, from a machine that has cluster access:
+docker cp ~/.kube/config homeassistant:/config/kubeconfig
+
+# HA OS / Supervised: copy it in with the Samba, SSH, Terminal,
+# or File Editor add-on instead — the destination is the same.
+```
+
+Then either **leave the Kubeconfig Path field empty** (the file is found automatically) or set it to `/config/kubeconfig`.
+
+> **Why the config directory?** On HA OS, Supervised, and Container installs the home directory (`~`, which is `/root`) lives inside the container image, so anything stored there is lost the next time the container is recreated or Home Assistant is updated. The config directory is a mounted volume and survives.
+
+#### What the Kubeconfig Path field accepts
+
+| Value | Result |
+|---|---|
+| _(empty)_ | The default locations below are searched |
+| `/config/kubeconfig` | That exact file is used |
+| `~/.kube/config` | `~` is expanded to the home directory of the user running Home Assistant |
+| `$MY_DIR/kubeconfig` | Environment variables are expanded |
+| `/config/.kube` | A directory — it is searched for `config`, `kubeconfig`, `kubeconfig.yaml`, `kubeconfig.yml` (also inside a `.kube` subdirectory) |
+| `/config/a.yaml:/config/b.yaml` | Multiple `:`-separated files, merged the same way the `KUBECONFIG` environment variable works |
+
+#### Default search order (empty path)
+
+1. Every path listed in the `KUBECONFIG` environment variable
+2. `<config dir>/.kube/` then `<config dir>/` — e.g. `/config/.kube/`, `/config/`
+3. `~/.kube/` then `~/`
+4. `/config/.kube/`, `/config/`, `/root/.kube/`
+
+In each directory the first match of `config`, `kubeconfig`, `kubeconfig.yaml`, or `kubeconfig.yml` is used.
+
+#### Kubeconfig requirements
+
+- Service account tokens, client certificates, and basic auth all work out of the box.
+- `exec:` credential plugins (`aws eks get-token`, `gke-gcloud-auth-plugin`, and similar) only work if that binary exists **inside** the Home Assistant container — usually it does not. Use a service account token instead (see the next step).
+- The API server address must be reachable from Home Assistant, and its certificate must validate — embed `certificate-authority-data` in the kubeconfig if you use a private CA.
+
+### Step 3 — Apply the Kubernetes RBAC
+
+The integration only needs read-only access to FluxCD resources. Apply the included manifest:
+
+```bash
+kubectl apply -f rbac.yaml
+```
+
+This creates a `ClusterRole` named `fluxcd-hass-reader` with `get`, `list`, and `watch` permissions on:
+
+- `gitrepositories`, `helmrepositories`, `helmcharts`, `buckets`, `ocirepositories`, `artifactgenerators`, `externalartifacts` (`source.toolkit.fluxcd.io`)
+- `kustomizations` (`kustomize.toolkit.fluxcd.io`)
+- `helmreleases` (`helm.toolkit.fluxcd.io`)
+- `fluxinstances`, `resourcesets`, `resourcesetinputproviders` (`fluxcd.controlplane.io`)
+
+Edit the `ClusterRoleBinding` subject at the bottom of `rbac.yaml` to match the service account Home Assistant authenticates as (the default is `home-assistant` in the `default` namespace).
+
+> **Controller monitoring** (source-controller, kustomize-controller, etc.) additionally
+> requires `get` and `list` on `deployments` in the `apps` API group. Without it the
+> integration still starts, but no controller entities appear. Add this rule to the
+> ClusterRole in `rbac.yaml` to enable it:
+>
+> ```yaml
+> - apiGroups:
+>     - apps
+>   resources:
+>     - deployments
+>   verbs:
+>     - get
+>     - list
+> ```
+
+### Step 4 — Add the integration in Home Assistant
+
+1. Go to **Settings → Devices & Services**
+2. Click **+ ADD INTEGRATION**
+3. Search for **FluxCD**
+4. Fill in the form:
+
+| Field | Description | Default |
+|---|---|---|
+| **Access Mode** | `In-Cluster` when Home Assistant runs inside Kubernetes, otherwise `Kubeconfig File` | Kubeconfig File |
+| **Kubeconfig Path** | Path to the kubeconfig file — see [Step 2](#step-2--choose-how-home-assistant-reaches-your-cluster). Leave empty to auto-detect | _(empty)_ |
+| **Namespace** | Namespace to monitor; leave empty for all namespaces | _(all namespaces)_ |
+| **Scan Interval** | Poll frequency in seconds (minimum 10, maximum 3600) | 60 |
+| **Label Selector** | Optional Kubernetes label selector, e.g. `app=myapp` | _(none)_ |
+
+You can add the integration more than once — for example one entry per namespace or per label selector.
+
+### Troubleshooting
+
+| Message or symptom | What to do |
+|---|---|
+| *No kubeconfig file was found* | The path does not exist, or nothing was found in the default locations. Copy the file to `/config/kubeconfig`, or enter its full path. A `~` path is fine, but the file must actually exist there. |
+| *Failed to connect to the Kubernetes cluster* | The kubeconfig was found but the cluster could not be reached. Check the API server URL, the certificate, and that the credentials have not expired. |
+| No controller entities | Add the `apps`/`deployments` RBAC rule from [Step 3](#step-3--apply-the-kubernetes-rbac). |
+| A resource type is missing | That CRD is not installed in the cluster; it is skipped silently (visible at debug level). |
+
+Enable debug logging to see which kubeconfig file was chosen and which resources were fetched:
+
+```yaml
+# configuration.yaml
+logger:
+  default: warning
+  logs:
+    custom_components.fluxcd_k8s: debug
+```
 
 ## Features
 
@@ -22,6 +183,14 @@ Repository: [fluxcd-topology-card on GitHub](https://github.com/dawg-io/fluxcd-t
 - **Label selector** filtering for targeted monitoring
 - **Configurable scan interval**
 - **Grouped and per-resource-type fetch functions** for flexible querying
+
+## Companion Lovelace Card
+
+The [**fluxcd-topology-card**](https://github.com/dawg-io/fluxcd-topology-card) is an optional companion custom card for Home Assistant dashboards. It visualizes the relationships between FluxCD resources (GitRepositories, HelmRepositories, HelmCharts, HelmReleases, Kustomizations, and more) as an interactive topology graph directly in your Lovelace UI.
+
+It is built to work alongside this integration and enhances the monitoring experience by providing a graphical overview of your FluxCD resource dependencies — but it is entirely optional and not required for this integration to function.
+
+Repository: [fluxcd-topology-card on GitHub](https://github.com/dawg-io/fluxcd-topology-card)
 
 ## Resource Categories
 
@@ -236,83 +405,6 @@ FluxCD controller Deployments (e.g., source-controller, kustomize-controller) ar
 - `Desired Replicas` — Expected replica count
 - `Ready Replicas` — Ready replica count
 - `Available Replicas` — Available replica count
-
-## Installation
-
-### HACS (Recommended)
-
-1. Add this repository as a custom repository in HACS
-2. Install the "FluxCD" integration
-3. Restart Home Assistant
-
-### Manual Installation
-
-1. Copy the `custom_components/fluxcd_k8s` directory to your Home Assistant `custom_components` directory:
-   ```bash
-   cp -r custom_components/fluxcd_k8s /path/to/homeassistant/custom_components/
-   ```
-2. Restart Home Assistant
-
-## Configuration
-
-1. Go to **Settings → Devices & Services**
-2. Click **+ ADD INTEGRATION**
-3. Search for **FluxCD**
-4. Configure the following:
-   - **Access Mode**: Select `In-Cluster` if Home Assistant runs inside Kubernetes, or `Kubeconfig File` for external access
-   - **Kubeconfig Path**: Path to your kubeconfig file (only needed for Kubeconfig mode; leave empty for the default `~/.kube/config`)
-   - **Namespace**: Kubernetes namespace to monitor (leave empty for all namespaces)
-   - **Scan Interval**: How often to poll FluxCD resources (in seconds, minimum 10, default 60)
-   - **Label Selector**: Optional Kubernetes label selector to filter resources
-
-## Kubernetes RBAC
-
-The integration requires read-only access to FluxCD custom resources. Apply the included RBAC manifest:
-
-```bash
-kubectl apply -f rbac.yaml
-```
-
-This creates a `ClusterRole` with `get`, `list`, and `watch` permissions on:
-- `gitrepositories`, `helmrepositories`, `helmcharts`, `buckets`, `ocirepositories`, `artifactgenerators`, `externalartifacts` (`source.toolkit.fluxcd.io`)
-- `kustomizations` (`kustomize.toolkit.fluxcd.io`)
-- `helmreleases` (`helm.toolkit.fluxcd.io`)
-- `fluxinstances`, `resourcesets`, `resourcesetinputproviders` (`fluxcd.controlplane.io`)
-
-Edit the `ClusterRoleBinding` subject to match your Home Assistant service account.
-
-> **Note:** Controller component monitoring (source-controller, kustomize-controller, etc.)
-> requires `get` and `list` access to `deployments` in the `apps` API group for the
-> `flux-system` namespace. If your service account does not have this permission the
-> integration will still start, but controller entities will not appear. Add the following
-> rule to the ClusterRole in `rbac.yaml` if you want controller monitoring:
->
-> ```yaml
-> - apiGroups:
->     - apps
->   resources:
->     - deployments
->   verbs:
->     - get
->     - list
-> ```
-
-## Project Structure
-
-```
-custom_components/fluxcd_k8s/
-├── __init__.py        # Integration setup and teardown
-├── manifest.json      # Integration metadata and requirements
-├── const.py           # Constants, CRD definitions, and category groupings
-├── config_flow.py     # Configuration UI flow
-├── coordinator.py     # DataUpdateCoordinator for polling
-├── api.py             # Kubernetes API client with grouped/per-type fetch functions
-├── models.py          # Data models and kind-specific parsing helpers
-├── sensor.py          # Sensor entity platform
-├── strings.json       # UI strings
-└── translations/
-    └── en.json        # English translations
-```
 
 ## How It Works
 
@@ -626,13 +718,23 @@ entities:
 > ```
 > Convert each name to a sensor entity ID by replacing hyphens and slashes with underscores, appending the resource type slug, and then `_status`. For example, a Kustomization named `helm-controller` in `flux-system` becomes `sensor.flux_system_helm_controller_kustomizations_status`.
 
-## Requirements
+## Project Structure
 
-- Home Assistant 2024.9.1+
-- Python 3.11+
-- `kubernetes-asyncio` (installed automatically)
-- Kubernetes cluster with FluxCD installed
-- Appropriate RBAC permissions (see above)
+```
+custom_components/fluxcd_k8s/
+├── __init__.py        # Integration setup and teardown
+├── manifest.json      # Integration metadata and requirements
+├── const.py           # Constants, CRD definitions, and category groupings
+├── config_flow.py     # Configuration UI flow
+├── coordinator.py     # DataUpdateCoordinator for polling
+├── api.py             # Kubernetes API client with grouped/per-type fetch functions
+├── kubeconfig.py      # Kubeconfig path expansion and default-location discovery
+├── models.py          # Data models and kind-specific parsing helpers
+├── sensor.py          # Sensor entity platform
+├── strings.json       # UI strings
+└── translations/
+    └── en.json        # English translations
+```
 
 ## License
 

--- a/custom_components/fluxcd_k8s/__init__.py
+++ b/custom_components/fluxcd_k8s/__init__.py
@@ -8,7 +8,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 
 from .api import FluxKubernetesClient
@@ -24,6 +24,7 @@ from .const import (
     FLUX_RESOURCES,
 )
 from .coordinator import FluxCDCoordinator
+from .kubeconfig import KubeconfigNotFound
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,6 +50,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         await k8s_client.async_init()
+    except KubeconfigNotFound as err:
+        # Not transient: retrying on a backoff will never find a file that is
+        # not there. Surface it as a config error the user can act on.
+        raise ConfigEntryError(str(err)) from err
     except Exception as err:
         raise ConfigEntryNotReady(
             f"Failed to initialize Kubernetes client: {err}"

--- a/custom_components/fluxcd_k8s/api.py
+++ b/custom_components/fluxcd_k8s/api.py
@@ -32,6 +32,7 @@ from .const import (
     FLUX_RESOURCESETINPUTPROVIDER,
     FLUX_SOURCES,
 )
+from .kubeconfig import KubeconfigNotFound, get_search_dirs, require_kubeconfig_path
 from .models import FluxResource, parse_controller_deployment, parse_flux_resource
 
 _LOGGER = logging.getLogger(__name__)
@@ -89,7 +90,9 @@ class FluxKubernetesClient:
             self._api_client = await self._async_create_api_client()
         else:
             kubeconfig = await self._hass.async_add_executor_job(
-                self._load_kubeconfig, self._kubeconfig_path or None
+                self._load_kubeconfig,
+                self._kubeconfig_path or None,
+                self._kubeconfig_search_dirs(),
             )
             client_configuration = client.Configuration()
             await config.load_kube_config_from_dict(
@@ -98,11 +101,33 @@ class FluxKubernetesClient:
             )
             self._api_client = await self._async_create_api_client(client_configuration)
 
+    def _kubeconfig_search_dirs(self) -> list[str]:
+        """Return the directories to search when no kubeconfig path is set.
+
+        The Home Assistant config directory is included so a kubeconfig stored
+        next to configuration.yaml (e.g. /config/kubeconfig) is picked up.
+        """
+        config_dir = getattr(self._hass.config, "config_dir", None)
+        return get_search_dirs(config_dir if isinstance(config_dir, str) else None)
+
     @staticmethod
-    def _load_kubeconfig(config_file: str | None) -> object:
-        """Load kubeconfig contents while keeping blocking file I/O off the event loop."""
-        kubeconfig_path = config_file or config.KUBE_CONFIG_DEFAULT_LOCATION
-        return config.kube_config.KubeConfigMerger(kubeconfig_path).config
+    def _load_kubeconfig(
+        config_file: str | None, search_dirs: list[str] | None = None
+    ) -> object:
+        """Load kubeconfig contents while keeping blocking file I/O off the event loop.
+
+        Resolves ``~``/environment variables in the configured path and falls
+        back to the well-known kubeconfig locations when no path is set.
+        """
+        kubeconfig_path = require_kubeconfig_path(config_file, search_dirs)
+        _LOGGER.debug("Loading kubeconfig from %s", kubeconfig_path)
+        merged = config.kube_config.KubeConfigMerger(kubeconfig_path).config
+        if merged is None:
+            raise KubeconfigNotFound(
+                f"The kubeconfig file at '{kubeconfig_path}' is empty or could not "
+                "be parsed as YAML."
+            )
+        return merged
 
     @staticmethod
     def _create_ssl_context(

--- a/custom_components/fluxcd_k8s/api.py
+++ b/custom_components/fluxcd_k8s/api.py
@@ -32,7 +32,11 @@ from .const import (
     FLUX_RESOURCESETINPUTPROVIDER,
     FLUX_SOURCES,
 )
-from .kubeconfig import KubeconfigNotFound, get_search_dirs, require_kubeconfig_path
+from .kubeconfig import (
+    KubeconfigNotFound,
+    get_search_dirs_for_hass,
+    require_kubeconfig_path,
+)
 from .models import FluxResource, parse_controller_deployment, parse_flux_resource
 
 _LOGGER = logging.getLogger(__name__)
@@ -92,7 +96,7 @@ class FluxKubernetesClient:
             kubeconfig = await self._hass.async_add_executor_job(
                 self._load_kubeconfig,
                 self._kubeconfig_path or None,
-                self._kubeconfig_search_dirs(),
+                get_search_dirs_for_hass(self._hass),
             )
             client_configuration = client.Configuration()
             await config.load_kube_config_from_dict(
@@ -100,15 +104,6 @@ class FluxKubernetesClient:
                 client_configuration=client_configuration,
             )
             self._api_client = await self._async_create_api_client(client_configuration)
-
-    def _kubeconfig_search_dirs(self) -> list[str]:
-        """Return the directories to search when no kubeconfig path is set.
-
-        The Home Assistant config directory is included so a kubeconfig stored
-        next to configuration.yaml (e.g. /config/kubeconfig) is picked up.
-        """
-        config_dir = getattr(self._hass.config, "config_dir", None)
-        return get_search_dirs(config_dir if isinstance(config_dir, str) else None)
 
     @staticmethod
     def _load_kubeconfig(
@@ -121,11 +116,18 @@ class FluxKubernetesClient:
         """
         kubeconfig_path = require_kubeconfig_path(config_file, search_dirs)
         _LOGGER.debug("Loading kubeconfig from %s", kubeconfig_path)
-        merged = config.kube_config.KubeConfigMerger(kubeconfig_path).config
+        try:
+            merged = config.kube_config.KubeConfigMerger(kubeconfig_path).config
+        except Exception as err:
+            # An empty or non-mapping file makes KubeConfigMerger fail deep
+            # inside the library; report the file we chose instead.
+            raise KubeconfigNotFound(
+                f"The kubeconfig file at '{kubeconfig_path}' is empty or is not "
+                f"valid kubeconfig YAML: {err}"
+            ) from err
         if merged is None:
             raise KubeconfigNotFound(
-                f"The kubeconfig file at '{kubeconfig_path}' is empty or could not "
-                "be parsed as YAML."
+                f"The kubeconfig file at '{kubeconfig_path}' is empty."
             )
         return merged
 

--- a/custom_components/fluxcd_k8s/config_flow.py
+++ b/custom_components/fluxcd_k8s/config_flow.py
@@ -25,7 +25,11 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
-from .kubeconfig import get_search_dirs, resolve_kubeconfig_path
+from .kubeconfig import (
+    KubeconfigNotFound,
+    get_search_dirs_for_hass,
+    resolve_kubeconfig_path,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,11 +66,10 @@ async def validate_input(
     # use ~ or environment variables, point at a directory, or be left empty —
     # in which case the well-known locations are searched.
     if access_mode == ACCESS_MODE_KUBECONFIG:
-        config_dir = getattr(hass.config, "config_dir", None)
         resolved_path = await hass.async_add_executor_job(
             resolve_kubeconfig_path,
             kubeconfig_path,
-            get_search_dirs(config_dir if isinstance(config_dir, str) else None),
+            get_search_dirs_for_hass(hass),
         )
         if not resolved_path:
             raise InvalidKubeconfigPath
@@ -86,8 +89,12 @@ async def validate_input(
             raise CannotConnect
     except CannotConnect:
         raise
-    except InvalidKubeconfigPath:
-        raise
+    except KubeconfigNotFound as err:
+        # The file disappeared between the check above and the load, or it
+        # turned out to be unreadable — report it as a path problem so the
+        # user sees the actionable message instead of "cannot connect".
+        _LOGGER.debug("Kubeconfig became unusable during validation: %s", err)
+        raise InvalidKubeconfigPath from err
     except Exception as err:
         _LOGGER.exception("Unexpected error during connection test")
         raise CannotConnect from err

--- a/custom_components/fluxcd_k8s/config_flow.py
+++ b/custom_components/fluxcd_k8s/config_flow.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any
 
 import voluptuous as vol
@@ -26,6 +25,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
+from .kubeconfig import get_search_dirs, resolve_kubeconfig_path
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,11 +58,19 @@ async def validate_input(
     access_mode = data[CONF_ACCESS_MODE]
     kubeconfig_path = data.get(CONF_KUBECONFIG_PATH, "")
 
-    # Validate kubeconfig path if specified
-    if access_mode == ACCESS_MODE_KUBECONFIG and kubeconfig_path:
-        exists = await hass.async_add_executor_job(os.path.isfile, kubeconfig_path)
-        if not exists:
+    # Resolve the kubeconfig location before attempting to connect. The path may
+    # use ~ or environment variables, point at a directory, or be left empty —
+    # in which case the well-known locations are searched.
+    if access_mode == ACCESS_MODE_KUBECONFIG:
+        config_dir = getattr(hass.config, "config_dir", None)
+        resolved_path = await hass.async_add_executor_job(
+            resolve_kubeconfig_path,
+            kubeconfig_path,
+            get_search_dirs(config_dir if isinstance(config_dir, str) else None),
+        )
+        if not resolved_path:
             raise InvalidKubeconfigPath
+        _LOGGER.debug("Resolved kubeconfig path to %s", resolved_path)
 
     k8s_client = FluxKubernetesClient(
         hass=hass,

--- a/custom_components/fluxcd_k8s/kubeconfig.py
+++ b/custom_components/fluxcd_k8s/kubeconfig.py
@@ -1,0 +1,186 @@
+"""Kubeconfig discovery helpers for the FluxCD integration.
+
+Home Assistant users store their kubeconfig in a handful of different places
+depending on how HA is installed, and they commonly type a path containing
+``~`` (for example ``~/.kube/config``).  A bare ``os.path.isfile()`` check
+rejects such a path because ``~`` is only meaningful to a shell, so this module
+normalizes user input and falls back to searching the usual locations.
+
+Everything here performs blocking file system calls — always run it in the
+executor, never on the event loop.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Iterable, Sequence
+
+_LOGGER = logging.getLogger(__name__)
+
+# File names a kubeconfig is commonly saved under.  ``config`` is the kubectl
+# default (``~/.kube/config``); the rest cover people who drop the file into
+# the Home Assistant config directory as ``kubeconfig``.
+KUBECONFIG_FILENAMES: tuple[str, ...] = (
+    "config",
+    "kubeconfig",
+    "kubeconfig.yaml",
+    "kubeconfig.yml",
+)
+
+# Directories searched when the kubeconfig path is left empty.  The Home
+# Assistant config directory is added on top of these at runtime, see
+# async_get_search_dirs().
+DEFAULT_SEARCH_DIRS: tuple[str, ...] = (
+    "~/.kube",
+    "~",
+    "/config/.kube",
+    "/config",
+    "/root/.kube",
+)
+
+
+class KubeconfigNotFound(Exception):
+    """Raised when no readable kubeconfig file can be located."""
+
+
+def get_search_dirs(config_dir: str | None = None) -> list[str]:
+    """Return the directories to search for a kubeconfig file.
+
+    ``config_dir`` is the Home Assistant configuration directory (``/config``
+    on container/OS installs, ``~/.homeassistant`` on core installs).  It is
+    searched first, both directly and via a ``.kube`` subdirectory, so a
+    kubeconfig placed next to ``configuration.yaml`` is found automatically.
+    """
+    dirs: list[str] = []
+    if config_dir:
+        dirs.extend([os.path.join(config_dir, ".kube"), config_dir])
+    dirs.extend(DEFAULT_SEARCH_DIRS)
+
+    # Preserve order while dropping duplicates (e.g. a container install where
+    # config_dir is already /config).
+    seen: set[str] = set()
+    unique_dirs: list[str] = []
+    for directory in dirs:
+        if directory and directory not in seen:
+            seen.add(directory)
+            unique_dirs.append(directory)
+    return unique_dirs
+
+
+def expand_path(path: str) -> str:
+    """Expand ``~`` and environment variables in a user supplied path."""
+    return os.path.expanduser(os.path.expandvars(path.strip()))
+
+
+def _find_in_dir(directory: str) -> str | None:
+    """Return the first known kubeconfig file name inside ``directory``."""
+    for candidate_dir in (directory, os.path.join(directory, ".kube")):
+        if not os.path.isdir(candidate_dir):
+            continue
+        for filename in KUBECONFIG_FILENAMES:
+            candidate = os.path.join(candidate_dir, filename)
+            if os.path.isfile(candidate):
+                return candidate
+    return None
+
+
+def resolve_path_entry(path: str) -> str | None:
+    """Resolve a single user supplied path to an existing kubeconfig file.
+
+    Accepts a file path (with ``~``/``$VAR`` expansion) or a directory, in
+    which case the directory — and a ``.kube`` subdirectory of it — is searched
+    for a known kubeconfig file name.  Returns None when nothing was found.
+    """
+    expanded = expand_path(path)
+    if not expanded:
+        return None
+    if os.path.isfile(expanded):
+        return expanded
+    return _find_in_dir(expanded)
+
+
+def _env_kubeconfig_entries() -> list[str]:
+    """Return the path entries from the KUBECONFIG environment variable."""
+    env_value = os.environ.get("KUBECONFIG", "")
+    return [entry for entry in env_value.split(os.pathsep) if entry.strip()]
+
+
+def _candidate_paths(search_dirs: Iterable[str]) -> list[str]:
+    """Return every path to probe when no kubeconfig path is configured."""
+    candidates = _env_kubeconfig_entries()
+    for directory in search_dirs:
+        candidates.extend(
+            os.path.join(directory, filename) for filename in KUBECONFIG_FILENAMES
+        )
+    return candidates
+
+
+def resolve_kubeconfig_path(
+    configured_path: str | None = None,
+    search_dirs: Sequence[str] | None = None,
+) -> str | None:
+    """Resolve the kubeconfig location, or return None when there is none.
+
+    When ``configured_path`` is set it is expanded and may point at a file, a
+    directory, or an ``os.pathsep`` separated list of either (the same syntax
+    the ``KUBECONFIG`` environment variable uses).  Entries that do not exist
+    are skipped, matching kubectl behavior.
+
+    When ``configured_path`` is empty the ``KUBECONFIG`` environment variable
+    and then ``search_dirs`` are probed for a file named ``config``,
+    ``kubeconfig``, ``kubeconfig.yaml``, or ``kubeconfig.yml``.
+
+    This performs blocking file system calls — run it in the executor.
+    """
+    if configured_path and configured_path.strip():
+        resolved: list[str] = []
+        for entry in configured_path.split(os.pathsep):
+            if not entry.strip():
+                continue
+            match = resolve_path_entry(entry)
+            if match:
+                resolved.append(match)
+            else:
+                _LOGGER.warning(
+                    "Configured kubeconfig path does not exist, skipping: %s", entry
+                )
+        if resolved:
+            return os.pathsep.join(resolved)
+        return None
+
+    for candidate in _candidate_paths(
+        search_dirs if search_dirs is not None else get_search_dirs()
+    ):
+        match = resolve_path_entry(candidate)
+        if match:
+            _LOGGER.debug("Using auto-discovered kubeconfig file: %s", match)
+            return match
+
+    return None
+
+
+def require_kubeconfig_path(
+    configured_path: str | None = None,
+    search_dirs: Sequence[str] | None = None,
+) -> str:
+    """Resolve the kubeconfig location or raise KubeconfigNotFound.
+
+    This performs blocking file system calls — run it in the executor.
+    """
+    resolved = resolve_kubeconfig_path(configured_path, search_dirs)
+    if resolved:
+        return resolved
+
+    if configured_path and configured_path.strip():
+        raise KubeconfigNotFound(
+            f"No kubeconfig file found at '{configured_path}'. Enter the full path "
+            "to the file (for example /config/kubeconfig) or leave the field empty "
+            "to search the default locations."
+        )
+    searched = search_dirs if search_dirs is not None else get_search_dirs()
+    raise KubeconfigNotFound(
+        "No kubeconfig file found. Searched the KUBECONFIG environment variable "
+        f"and these directories: {', '.join(searched)}. Copy your kubeconfig to "
+        "one of them or enter its full path."
+    )

--- a/custom_components/fluxcd_k8s/kubeconfig.py
+++ b/custom_components/fluxcd_k8s/kubeconfig.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,15 +28,14 @@ KUBECONFIG_FILENAMES: tuple[str, ...] = (
     "kubeconfig.yml",
 )
 
-# Directories searched when the kubeconfig path is left empty.  The Home
-# Assistant config directory is added on top of these at runtime, see
-# async_get_search_dirs().
+# Directories searched when the kubeconfig path is left empty.  Each one is
+# probed via its ``.kube`` subdirectory first and then directly, so listing
+# ``~`` also covers ``~/.kube``.  The Home Assistant config directory is added
+# in front of these at runtime, see get_search_dirs().
 DEFAULT_SEARCH_DIRS: tuple[str, ...] = (
-    "~/.kube",
     "~",
-    "/config/.kube",
     "/config",
-    "/root/.kube",
+    "/root",
 )
 
 
@@ -49,23 +48,35 @@ def get_search_dirs(config_dir: str | None = None) -> list[str]:
 
     ``config_dir`` is the Home Assistant configuration directory (``/config``
     on container/OS installs, ``~/.homeassistant`` on core installs).  It is
-    searched first, both directly and via a ``.kube`` subdirectory, so a
-    kubeconfig placed next to ``configuration.yaml`` is found automatically.
+    searched first so a kubeconfig placed next to ``configuration.yaml`` is
+    found automatically.
     """
-    dirs: list[str] = []
-    if config_dir:
-        dirs.extend([os.path.join(config_dir, ".kube"), config_dir])
+    dirs: list[str] = [config_dir] if config_dir else []
     dirs.extend(DEFAULT_SEARCH_DIRS)
 
     # Preserve order while dropping duplicates (e.g. a container install where
-    # config_dir is already /config).
+    # config_dir is already /config, possibly with a trailing separator).
     seen: set[str] = set()
     unique_dirs: list[str] = []
     for directory in dirs:
-        if directory and directory not in seen:
-            seen.add(directory)
+        if not directory:
+            continue
+        key = os.path.normpath(directory)
+        if key not in seen:
+            seen.add(key)
             unique_dirs.append(directory)
     return unique_dirs
+
+
+def get_search_dirs_for_hass(hass) -> list[str]:
+    """Return the search directories for a Home Assistant instance.
+
+    Only reads attributes, so it is safe to call on the event loop.  Keeping
+    this in one place stops the config flow and the API client from disagreeing
+    about where a kubeconfig may live.
+    """
+    config_dir = getattr(getattr(hass, "config", None), "config_dir", None)
+    return get_search_dirs(config_dir if isinstance(config_dir, str) else None)
 
 
 def expand_path(path: str) -> str:
@@ -74,8 +85,12 @@ def expand_path(path: str) -> str:
 
 
 def _find_in_dir(directory: str) -> str | None:
-    """Return the first known kubeconfig file name inside ``directory``."""
-    for candidate_dir in (directory, os.path.join(directory, ".kube")):
+    """Return the first known kubeconfig file name inside ``directory``.
+
+    A ``.kube`` subdirectory is checked first so the kubectl default
+    (``~/.kube/config``) wins over a stray ``~/kubeconfig``.
+    """
+    for candidate_dir in (os.path.join(directory, ".kube"), directory):
         if not os.path.isdir(candidate_dir):
             continue
         for filename in KUBECONFIG_FILENAMES:
@@ -100,20 +115,27 @@ def resolve_path_entry(path: str) -> str | None:
     return _find_in_dir(expanded)
 
 
-def _env_kubeconfig_entries() -> list[str]:
-    """Return the path entries from the KUBECONFIG environment variable."""
-    env_value = os.environ.get("KUBECONFIG", "")
-    return [entry for entry in env_value.split(os.pathsep) if entry.strip()]
+def _resolve_path_list(paths: str, *, warn_missing: bool) -> str | None:
+    """Resolve an ``os.pathsep`` separated list to the entries that exist.
 
-
-def _candidate_paths(search_dirs: Iterable[str]) -> list[str]:
-    """Return every path to probe when no kubeconfig path is configured."""
-    candidates = _env_kubeconfig_entries()
-    for directory in search_dirs:
-        candidates.extend(
-            os.path.join(directory, filename) for filename in KUBECONFIG_FILENAMES
-        )
-    return candidates
+    Missing entries are skipped rather than failing the whole list, which is
+    how kubectl treats ``KUBECONFIG``.  Returns the surviving entries joined
+    back together so they are merged downstream, or None if none exist.
+    """
+    resolved: list[str] = []
+    for entry in paths.split(os.pathsep):
+        if not entry.strip():
+            continue
+        match = resolve_path_entry(entry)
+        if match:
+            resolved.append(match)
+        elif warn_missing:
+            _LOGGER.warning(
+                "Configured kubeconfig path does not exist, skipping: %s", entry
+            )
+        else:
+            _LOGGER.debug("Kubeconfig path does not exist, skipping: %s", entry)
+    return os.pathsep.join(resolved) if resolved else None
 
 
 def resolve_kubeconfig_path(
@@ -124,35 +146,28 @@ def resolve_kubeconfig_path(
 
     When ``configured_path`` is set it is expanded and may point at a file, a
     directory, or an ``os.pathsep`` separated list of either (the same syntax
-    the ``KUBECONFIG`` environment variable uses).  Entries that do not exist
-    are skipped, matching kubectl behavior.
+    the ``KUBECONFIG`` environment variable uses).
 
     When ``configured_path`` is empty the ``KUBECONFIG`` environment variable
-    and then ``search_dirs`` are probed for a file named ``config``,
-    ``kubeconfig``, ``kubeconfig.yaml``, or ``kubeconfig.yml``.
+    is used if it names any existing file — all of its entries, so a split
+    cluster/credentials setup still merges — and otherwise ``search_dirs`` are
+    probed for a file named ``config``, ``kubeconfig``, ``kubeconfig.yaml``, or
+    ``kubeconfig.yml``.
 
     This performs blocking file system calls — run it in the executor.
     """
     if configured_path and configured_path.strip():
-        resolved: list[str] = []
-        for entry in configured_path.split(os.pathsep):
-            if not entry.strip():
-                continue
-            match = resolve_path_entry(entry)
-            if match:
-                resolved.append(match)
-            else:
-                _LOGGER.warning(
-                    "Configured kubeconfig path does not exist, skipping: %s", entry
-                )
-        if resolved:
-            return os.pathsep.join(resolved)
-        return None
+        return _resolve_path_list(configured_path, warn_missing=True)
 
-    for candidate in _candidate_paths(
-        search_dirs if search_dirs is not None else get_search_dirs()
-    ):
-        match = resolve_path_entry(candidate)
+    from_env = _resolve_path_list(
+        os.environ.get("KUBECONFIG", ""), warn_missing=False
+    )
+    if from_env:
+        _LOGGER.debug("Using kubeconfig from the KUBECONFIG variable: %s", from_env)
+        return from_env
+
+    for directory in search_dirs if search_dirs is not None else get_search_dirs():
+        match = _find_in_dir(expand_path(directory))
         if match:
             _LOGGER.debug("Using auto-discovered kubeconfig file: %s", match)
             return match

--- a/custom_components/fluxcd_k8s/strings.json
+++ b/custom_components/fluxcd_k8s/strings.json
@@ -13,7 +13,7 @@
         },
         "data_description": {
           "access_mode": "Select 'In-Cluster' if Home Assistant runs inside Kubernetes, or 'Kubeconfig File' for external access",
-          "kubeconfig_path": "Path to the kubeconfig file (leave empty for default location, only used with Kubeconfig mode)",
+          "kubeconfig_path": "Path to the kubeconfig file, e.g. /config/kubeconfig or ~/.kube/config (a directory containing the file also works). Leave empty to search KUBECONFIG, the Home Assistant config directory, and ~/.kube. Only used with Kubeconfig mode",
           "namespace": "Kubernetes namespace to monitor (leave empty for all namespaces)",
           "scan_interval": "How often to poll FluxCD resources (in seconds, minimum 10)",
           "label_selector": "Optional Kubernetes label selector to filter resources (e.g. 'app=myapp')"
@@ -22,7 +22,7 @@
     },
     "error": {
       "cannot_connect": "Failed to connect to the Kubernetes cluster. Please check your configuration.",
-      "invalid_kubeconfig_path": "The specified kubeconfig file does not exist.",
+      "invalid_kubeconfig_path": "No kubeconfig file was found. Enter the full path to the file (e.g. /config/kubeconfig or ~/.kube/config), or leave the field empty to search KUBECONFIG, the Home Assistant config directory, and ~/.kube.",
       "unknown": "An unexpected error occurred. Please check the logs for more details."
     },
     "abort": {

--- a/custom_components/fluxcd_k8s/translations/en.json
+++ b/custom_components/fluxcd_k8s/translations/en.json
@@ -13,7 +13,7 @@
         },
         "data_description": {
           "access_mode": "Select 'In-Cluster' if Home Assistant runs inside Kubernetes, or 'Kubeconfig File' for external access",
-          "kubeconfig_path": "Path to the kubeconfig file (leave empty for default location, only used with Kubeconfig mode)",
+          "kubeconfig_path": "Path to the kubeconfig file, e.g. /config/kubeconfig or ~/.kube/config (a directory containing the file also works). Leave empty to search KUBECONFIG, the Home Assistant config directory, and ~/.kube. Only used with Kubeconfig mode",
           "namespace": "Kubernetes namespace to monitor (leave empty for all namespaces)",
           "scan_interval": "How often to poll FluxCD resources (in seconds, minimum 10)",
           "label_selector": "Optional Kubernetes label selector to filter resources (e.g. 'app=myapp')"
@@ -22,7 +22,7 @@
     },
     "error": {
       "cannot_connect": "Failed to connect to the Kubernetes cluster. Please check your configuration.",
-      "invalid_kubeconfig_path": "The specified kubeconfig file does not exist.",
+      "invalid_kubeconfig_path": "No kubeconfig file was found. Enter the full path to the file (e.g. /config/kubeconfig or ~/.kube/config), or leave the field empty to search KUBECONFIG, the Home Assistant config directory, and ~/.kube.",
       "unknown": "An unexpected error occurred. Please check the logs for more details."
     },
     "abort": {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -65,6 +65,9 @@ def _load_api_module():
 _api_module = _load_api_module()
 FluxKubernetesClient = _api_module.FluxKubernetesClient
 
+# Imported by api.py via a relative import, so it is already in sys.modules.
+KubeconfigNotFound = sys.modules["fluxcd_k8s.kubeconfig"].KubeconfigNotFound
+
 
 # ---------------------------------------------------------------------------
 # Tests
@@ -225,9 +228,14 @@ class TestAsyncInit:
             FluxKubernetesClient(hass=None, access_mode=_api_module.ACCESS_MODE_IN_CLUSTER)
 
     @pytest.mark.asyncio
-    async def test_kubeconfig_init_loads_kubeconfig_in_executor(self):
+    async def test_kubeconfig_init_loads_kubeconfig_in_executor(self, tmp_path):
         """Kubeconfig file reads must happen in the executor to avoid loop blocking."""
+        kubeconfig_file = tmp_path / ".kube" / "config"
+        kubeconfig_file.parent.mkdir()
+        kubeconfig_file.write_text("apiVersion: v1\n")
+
         hass = MagicMock()
+        hass.config.config_dir = str(tmp_path)
 
         async def _run_in_executor(func, *args):
             return func(*args)
@@ -246,12 +254,6 @@ class TestAsyncInit:
             ),
             patch.object(
                 _api_module.config,
-                "KUBE_CONFIG_DEFAULT_LOCATION",
-                "/default/.kube/config",
-                create=True,
-            ),
-            patch.object(
-                _api_module.config,
                 "load_kube_config_from_dict",
                 load_kube_config_from_dict,
                 create=True,
@@ -260,17 +262,19 @@ class TestAsyncInit:
             flux_client = FluxKubernetesClient(
                 hass=hass,
                 access_mode="kubeconfig",
-                kubeconfig_path="/config/.kube/config",
+                kubeconfig_path=str(kubeconfig_file),
             )
             flux_client._async_create_api_client = AsyncMock(return_value=api_client)
 
             await flux_client.async_init()
 
             hass.async_add_executor_job.assert_awaited_once_with(
-                flux_client._load_kubeconfig, "/config/.kube/config"
+                flux_client._load_kubeconfig,
+                str(kubeconfig_file),
+                _api_module.get_search_dirs(str(tmp_path)),
             )
             kube_config_module.KubeConfigMerger.assert_called_once_with(
-                "/config/.kube/config"
+                str(kubeconfig_file)
             )
             load_kube_config_from_dict.assert_awaited_once()
             called_kwargs = load_kube_config_from_dict.await_args.kwargs
@@ -279,6 +283,74 @@ class TestAsyncInit:
                 called_kwargs["client_configuration"]
             )
             assert flux_client._api_client is api_client
+
+    @pytest.mark.asyncio
+    async def test_kubeconfig_init_expands_home_shortcut(self, tmp_path, monkeypatch):
+        """A '~/.kube/config' path must be expanded before the file is read."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        kubeconfig_file = tmp_path / ".kube" / "config"
+        kubeconfig_file.parent.mkdir()
+        kubeconfig_file.write_text("apiVersion: v1\n")
+
+        hass = MagicMock()
+        hass.config.config_dir = str(tmp_path)
+
+        async def _run_in_executor(func, *args):
+            return func(*args)
+
+        hass.async_add_executor_job = AsyncMock(side_effect=_run_in_executor)
+
+        merger = MagicMock(config={"apiVersion": "v1"})
+        kube_config_module = MagicMock(KubeConfigMerger=MagicMock(return_value=merger))
+
+        with (
+            patch.object(
+                _api_module.config, "kube_config", kube_config_module, create=True
+            ),
+            patch.object(
+                _api_module.config,
+                "load_kube_config_from_dict",
+                AsyncMock(),
+                create=True,
+            ),
+        ):
+            flux_client = FluxKubernetesClient(
+                hass=hass,
+                access_mode="kubeconfig",
+                kubeconfig_path="~/.kube/config",
+            )
+            flux_client._async_create_api_client = AsyncMock(return_value=object())
+
+            await flux_client.async_init()
+
+        kube_config_module.KubeConfigMerger.assert_called_once_with(
+            str(kubeconfig_file)
+        )
+
+    @pytest.mark.asyncio
+    async def test_kubeconfig_init_raises_when_no_kubeconfig_found(
+        self, tmp_path, monkeypatch
+    ):
+        """A missing kubeconfig must fail with a clear, actionable error."""
+        monkeypatch.delenv("KUBECONFIG", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+
+        hass = MagicMock()
+        hass.config.config_dir = str(tmp_path)
+
+        async def _run_in_executor(func, *args):
+            return func(*args)
+
+        hass.async_add_executor_job = AsyncMock(side_effect=_run_in_executor)
+
+        flux_client = FluxKubernetesClient(
+            hass=hass,
+            access_mode="kubeconfig",
+            kubeconfig_path=str(tmp_path / "nope" / "kubeconfig"),
+        )
+
+        with pytest.raises(KubeconfigNotFound, match="No kubeconfig file"):
+            await flux_client.async_init()
 
     @pytest.mark.asyncio
     async def test_async_create_api_client_offloads_ssl_context_creation(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -66,7 +66,19 @@ _api_module = _load_api_module()
 FluxKubernetesClient = _api_module.FluxKubernetesClient
 
 # Imported by api.py via a relative import, so it is already in sys.modules.
-KubeconfigNotFound = sys.modules["fluxcd_k8s.kubeconfig"].KubeconfigNotFound
+_kubeconfig_module = sys.modules["fluxcd_k8s.kubeconfig"]
+KubeconfigNotFound = _kubeconfig_module.KubeconfigNotFound
+
+
+@pytest.fixture(autouse=True)
+def _isolate_kubeconfig_search(monkeypatch):
+    """Stop discovery from reaching a kubeconfig on the machine running tests.
+
+    DEFAULT_SEARCH_DIRS points at /config and /root, which do exist on the
+    systems this integration targets.
+    """
+    monkeypatch.delenv("KUBECONFIG", raising=False)
+    monkeypatch.setattr(_kubeconfig_module, "DEFAULT_SEARCH_DIRS", ())
 
 
 # ---------------------------------------------------------------------------
@@ -271,7 +283,7 @@ class TestAsyncInit:
             hass.async_add_executor_job.assert_awaited_once_with(
                 flux_client._load_kubeconfig,
                 str(kubeconfig_file),
-                _api_module.get_search_dirs(str(tmp_path)),
+                _api_module.get_search_dirs_for_hass(hass),
             )
             kube_config_module.KubeConfigMerger.assert_called_once_with(
                 str(kubeconfig_file)
@@ -351,6 +363,42 @@ class TestAsyncInit:
 
         with pytest.raises(KubeconfigNotFound, match="No kubeconfig file"):
             await flux_client.async_init()
+
+    @pytest.mark.asyncio
+    async def test_kubeconfig_init_reports_an_unparseable_file(self, tmp_path):
+        """A file that exists but is not kubeconfig YAML must name the file.
+
+        KubeConfigMerger fails inside the library on an empty file, so the
+        error has to be translated rather than allowed to escape raw.
+        """
+        kubeconfig_file = tmp_path / "kubeconfig"
+        kubeconfig_file.write_text("")
+
+        hass = MagicMock()
+        hass.config.config_dir = str(tmp_path)
+
+        async def _run_in_executor(func, *args):
+            return func(*args)
+
+        hass.async_add_executor_job = AsyncMock(side_effect=_run_in_executor)
+
+        kube_config_module = MagicMock(
+            KubeConfigMerger=MagicMock(
+                side_effect=TypeError("'NoneType' object does not support item assignment")
+            )
+        )
+
+        with patch.object(
+            _api_module.config, "kube_config", kube_config_module, create=True
+        ):
+            flux_client = FluxKubernetesClient(
+                hass=hass,
+                access_mode="kubeconfig",
+                kubeconfig_path=str(kubeconfig_file),
+            )
+
+            with pytest.raises(KubeconfigNotFound, match="is empty or is not"):
+                await flux_client.async_init()
 
     @pytest.mark.asyncio
     async def test_async_create_api_client_offloads_ssl_context_creation(self):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -76,11 +76,19 @@ _config_flow = _load_config_flow_module()
 _const = sys.modules["fluxcd_k8s.const"]
 
 
+def _hass_with_config_dir(config_dir: str = "/config") -> AsyncMock:
+    """Return a hass mock whose config directory is a real string."""
+    hass = AsyncMock()
+    hass.config = MagicMock()
+    hass.config.config_dir = config_dir
+    return hass
+
+
 class TestValidateInput:
     @pytest.mark.asyncio
     async def test_kubeconfig_path_check_runs_in_executor(self):
-        hass = AsyncMock()
-        hass.async_add_executor_job = AsyncMock(return_value=False)
+        hass = _hass_with_config_dir()
+        hass.async_add_executor_job = AsyncMock(return_value=None)
 
         data = {
             _const.CONF_ACCESS_MODE: _const.ACCESS_MODE_KUBECONFIG,
@@ -91,13 +99,15 @@ class TestValidateInput:
             await _config_flow.validate_input(hass, data)
 
         hass.async_add_executor_job.assert_awaited_once_with(
-            _config_flow.os.path.isfile, "/does/not/exist"
+            _config_flow.resolve_kubeconfig_path,
+            "/does/not/exist",
+            _config_flow.get_search_dirs("/config"),
         )
 
     @pytest.mark.asyncio
     async def test_kubeconfig_valid_path_passes_hass_to_client(self):
-        hass = AsyncMock()
-        hass.async_add_executor_job = AsyncMock(return_value=True)
+        hass = _hass_with_config_dir()
+        hass.async_add_executor_job = AsyncMock(return_value="/does/exist")
 
         mock_client = MagicMock()
         mock_client.async_init = AsyncMock(return_value=None)
@@ -115,7 +125,9 @@ class TestValidateInput:
             result = await _config_flow.validate_input(hass, data)
 
         hass.async_add_executor_job.assert_awaited_once_with(
-            _config_flow.os.path.isfile, "/does/exist"
+            _config_flow.resolve_kubeconfig_path,
+            "/does/exist",
+            _config_flow.get_search_dirs("/config"),
         )
         mock_client_class.assert_called_once_with(
             hass=hass,
@@ -127,4 +139,92 @@ class TestValidateInput:
         mock_client.async_init.assert_awaited_once()
         mock_client.async_test_connection.assert_awaited_once()
         mock_client.async_close.assert_awaited_once()
+        assert result["title"] == "FluxCD (all namespaces)"
+
+    @pytest.mark.asyncio
+    async def test_tilde_kubeconfig_path_is_accepted(self, tmp_path, monkeypatch):
+        """'~/.kube/config' must resolve instead of being rejected as missing."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        kube_dir = tmp_path / ".kube"
+        kube_dir.mkdir()
+        (kube_dir / "config").write_text("apiVersion: v1\n")
+
+        hass = _hass_with_config_dir(str(tmp_path))
+
+        async def _run_in_executor(func, *args):
+            return func(*args)
+
+        hass.async_add_executor_job = AsyncMock(side_effect=_run_in_executor)
+
+        mock_client = MagicMock()
+        mock_client.async_init = AsyncMock(return_value=None)
+        mock_client.async_test_connection = AsyncMock(return_value=True)
+        mock_client.async_close = AsyncMock(return_value=None)
+
+        data = {
+            _const.CONF_ACCESS_MODE: _const.ACCESS_MODE_KUBECONFIG,
+            _const.CONF_KUBECONFIG_PATH: "~/.kube/config",
+        }
+
+        with patch.object(
+            _config_flow, "FluxKubernetesClient", return_value=mock_client
+        ) as mock_client_class:
+            result = await _config_flow.validate_input(hass, data)
+
+        # The unexpanded path is stored; expansion happens when it is used.
+        assert mock_client_class.call_args.kwargs["kubeconfig_path"] == "~/.kube/config"
+        assert result["title"] == "FluxCD (all namespaces)"
+
+    @pytest.mark.asyncio
+    async def test_empty_kubeconfig_path_discovers_config_dir_file(
+        self, tmp_path, monkeypatch
+    ):
+        """An empty path falls back to a 'kubeconfig' file in the HA config dir."""
+        monkeypatch.delenv("KUBECONFIG", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+        (tmp_path / "kubeconfig").write_text("apiVersion: v1\n")
+
+        hass = _hass_with_config_dir(str(tmp_path))
+
+        async def _run_in_executor(func, *args):
+            return func(*args)
+
+        hass.async_add_executor_job = AsyncMock(side_effect=_run_in_executor)
+
+        mock_client = MagicMock()
+        mock_client.async_init = AsyncMock(return_value=None)
+        mock_client.async_test_connection = AsyncMock(return_value=True)
+        mock_client.async_close = AsyncMock(return_value=None)
+
+        data = {
+            _const.CONF_ACCESS_MODE: _const.ACCESS_MODE_KUBECONFIG,
+            _const.CONF_KUBECONFIG_PATH: "",
+        }
+
+        with patch.object(
+            _config_flow, "FluxKubernetesClient", return_value=mock_client
+        ):
+            result = await _config_flow.validate_input(hass, data)
+
+        assert result["title"] == "FluxCD (all namespaces)"
+
+    @pytest.mark.asyncio
+    async def test_in_cluster_mode_skips_kubeconfig_lookup(self):
+        """In-cluster mode must not look for a kubeconfig file."""
+        hass = _hass_with_config_dir()
+        hass.async_add_executor_job = AsyncMock()
+
+        mock_client = MagicMock()
+        mock_client.async_init = AsyncMock(return_value=None)
+        mock_client.async_test_connection = AsyncMock(return_value=True)
+        mock_client.async_close = AsyncMock(return_value=None)
+
+        data = {_const.CONF_ACCESS_MODE: _const.ACCESS_MODE_IN_CLUSTER}
+
+        with patch.object(
+            _config_flow, "FluxKubernetesClient", return_value=mock_client
+        ):
+            result = await _config_flow.validate_input(hass, data)
+
+        hass.async_add_executor_job.assert_not_awaited()
         assert result["title"] == "FluxCD (all namespaces)"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -74,6 +74,14 @@ def _load_config_flow_module():
 
 _config_flow = _load_config_flow_module()
 _const = sys.modules["fluxcd_k8s.const"]
+_kubeconfig = sys.modules["fluxcd_k8s.kubeconfig"]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_kubeconfig_search(monkeypatch):
+    """Stop discovery from reaching a kubeconfig on the machine running tests."""
+    monkeypatch.delenv("KUBECONFIG", raising=False)
+    monkeypatch.setattr(_kubeconfig, "DEFAULT_SEARCH_DIRS", ())
 
 
 def _hass_with_config_dir(config_dir: str = "/config") -> AsyncMock:
@@ -101,7 +109,7 @@ class TestValidateInput:
         hass.async_add_executor_job.assert_awaited_once_with(
             _config_flow.resolve_kubeconfig_path,
             "/does/not/exist",
-            _config_flow.get_search_dirs("/config"),
+            _config_flow.get_search_dirs_for_hass(hass),
         )
 
     @pytest.mark.asyncio
@@ -127,7 +135,7 @@ class TestValidateInput:
         hass.async_add_executor_job.assert_awaited_once_with(
             _config_flow.resolve_kubeconfig_path,
             "/does/exist",
-            _config_flow.get_search_dirs("/config"),
+            _config_flow.get_search_dirs_for_hass(hass),
         )
         mock_client_class.assert_called_once_with(
             hass=hass,
@@ -207,6 +215,35 @@ class TestValidateInput:
             result = await _config_flow.validate_input(hass, data)
 
         assert result["title"] == "FluxCD (all namespaces)"
+
+    @pytest.mark.asyncio
+    async def test_kubeconfig_lost_during_validation_is_a_path_error(self):
+        """KubeconfigNotFound must not be flattened into 'cannot connect'.
+
+        The pre-check and the actual load are two separate filesystem scans, so
+        the file can disappear in between; the user needs the path message.
+        """
+        hass = _hass_with_config_dir()
+        hass.async_add_executor_job = AsyncMock(return_value="/was/here")
+
+        mock_client = MagicMock()
+        mock_client.async_init = AsyncMock(
+            side_effect=_kubeconfig.KubeconfigNotFound("No kubeconfig file found.")
+        )
+        mock_client.async_close = AsyncMock(return_value=None)
+
+        data = {
+            _const.CONF_ACCESS_MODE: _const.ACCESS_MODE_KUBECONFIG,
+            _const.CONF_KUBECONFIG_PATH: "/was/here",
+        }
+
+        with (
+            patch.object(_config_flow, "FluxKubernetesClient", return_value=mock_client),
+            pytest.raises(_config_flow.InvalidKubeconfigPath),
+        ):
+            await _config_flow.validate_input(hass, data)
+
+        mock_client.async_close.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_in_cluster_mode_skips_kubeconfig_lookup(self):

--- a/tests/test_kubeconfig.py
+++ b/tests/test_kubeconfig.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import os
+import types
 
 import pytest
+from fluxcd_k8s import kubeconfig as kc
 from fluxcd_k8s.kubeconfig import (
-    DEFAULT_SEARCH_DIRS,
     KubeconfigNotFound,
     expand_path,
     get_search_dirs,
+    get_search_dirs_for_hass,
     require_kubeconfig_path,
     resolve_kubeconfig_path,
     resolve_path_entry,
@@ -18,10 +20,16 @@ from fluxcd_k8s.kubeconfig import (
 
 @pytest.fixture(autouse=True)
 def _isolated_env(monkeypatch, tmp_path):
-    """Keep the host's real kubeconfig out of every test."""
+    """Keep the host's real kubeconfig out of every test.
+
+    DEFAULT_SEARCH_DIRS holds absolute paths (/config, /root) that exist on the
+    machines this integration targets, so it is redirected at the temporary
+    home as well — otherwise a host kubeconfig would decide the result.
+    """
     monkeypatch.delenv("KUBECONFIG", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
     (tmp_path / "home").mkdir()
+    monkeypatch.setattr(kc, "DEFAULT_SEARCH_DIRS", ("~",))
 
 
 def _write_kubeconfig(path):
@@ -111,27 +119,78 @@ class TestResolveKubeconfigPath:
         _write_kubeconfig(tmp_path / "home" / ".kube" / "config")
         assert resolve_kubeconfig_path("", get_search_dirs()) == expected
 
+    def test_kubeconfig_env_var_keeps_every_existing_entry(
+        self, tmp_path, monkeypatch
+    ):
+        """A split cluster/credentials KUBECONFIG must still be merged."""
+        first = _write_kubeconfig(tmp_path / "env" / "cluster.yaml")
+        second = _write_kubeconfig(tmp_path / "env" / "user.yaml")
+        monkeypatch.setenv("KUBECONFIG", os.pathsep.join([first, second]))
+        assert resolve_kubeconfig_path("", get_search_dirs()) == os.pathsep.join(
+            [first, second]
+        )
+
+    def test_kubeconfig_env_var_skips_missing_entries(self, tmp_path, monkeypatch):
+        existing = _write_kubeconfig(tmp_path / "env" / "cluster.yaml")
+        monkeypatch.setenv(
+            "KUBECONFIG", os.pathsep.join([str(tmp_path / "gone.yaml"), existing])
+        )
+        assert resolve_kubeconfig_path("", get_search_dirs()) == existing
+
+    def test_empty_kubeconfig_env_var_falls_back_to_search_dirs(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("KUBECONFIG", str(tmp_path / "does-not-exist"))
+        expected = _write_kubeconfig(tmp_path / "home" / ".kube" / "config")
+        assert resolve_kubeconfig_path("", get_search_dirs()) == expected
+
+    def test_directory_named_config_does_not_shadow_a_real_file(self, tmp_path):
+        """A `config/` directory must not outrank a `kubeconfig` file beside it."""
+        _write_kubeconfig(tmp_path / "search" / "config" / "kubeconfig")
+        expected = _write_kubeconfig(tmp_path / "search" / "kubeconfig")
+        assert resolve_kubeconfig_path("", [str(tmp_path / "search")]) == expected
+
+    def test_dot_kube_wins_over_a_loose_file_in_the_same_dir(self, tmp_path):
+        expected = _write_kubeconfig(tmp_path / "search" / ".kube" / "config")
+        _write_kubeconfig(tmp_path / "search" / "kubeconfig")
+        assert resolve_kubeconfig_path("", [str(tmp_path / "search")]) == expected
+
+    def test_search_dirs_are_expanded(self, tmp_path):
+        expected = _write_kubeconfig(tmp_path / "home" / ".kube" / "config")
+        assert resolve_kubeconfig_path("", ["~"]) == expected
+
     def test_returns_none_when_nothing_exists(self, tmp_path):
         assert resolve_kubeconfig_path("", [str(tmp_path / "nowhere")]) is None
 
 
 class TestGetSearchDirs:
     def test_config_dir_is_searched_first(self):
-        dirs = get_search_dirs("/config")
-        assert dirs[0] == os.path.join("/config", ".kube")
-        assert dirs[1] == "/config"
+        assert get_search_dirs("/config")[0] == "/config"
 
     def test_defaults_are_included(self):
-        dirs = get_search_dirs("/config")
-        for default_dir in DEFAULT_SEARCH_DIRS:
+        dirs = get_search_dirs("/somewhere/else")
+        for default_dir in kc.DEFAULT_SEARCH_DIRS:
             assert default_dir in dirs
 
-    def test_duplicates_are_removed(self):
-        dirs = get_search_dirs("/config")
-        assert len(dirs) == len(set(dirs))
+    def test_duplicates_are_removed(self, monkeypatch):
+        monkeypatch.setattr(kc, "DEFAULT_SEARCH_DIRS", ("~", "/config", "/root"))
+        assert get_search_dirs("/config/") == ["/config/", "~", "/root"]
 
     def test_without_config_dir_returns_defaults(self):
-        assert get_search_dirs() == list(DEFAULT_SEARCH_DIRS)
+        assert get_search_dirs() == list(kc.DEFAULT_SEARCH_DIRS)
+
+
+class TestGetSearchDirsForHass:
+    def test_uses_the_home_assistant_config_dir(self):
+        hass = types.SimpleNamespace(config=types.SimpleNamespace(config_dir="/ha"))
+        assert get_search_dirs_for_hass(hass)[0] == "/ha"
+
+    def test_ignores_a_non_string_config_dir(self):
+        hass = types.SimpleNamespace(config=types.SimpleNamespace(config_dir=object()))
+        assert get_search_dirs_for_hass(hass) == list(kc.DEFAULT_SEARCH_DIRS)
+
+    def test_tolerates_a_hass_without_config(self):
+        assert get_search_dirs_for_hass(object()) == list(kc.DEFAULT_SEARCH_DIRS)
 
 
 class TestRequireKubeconfigPath:

--- a/tests/test_kubeconfig.py
+++ b/tests/test_kubeconfig.py
@@ -1,0 +1,149 @@
+"""Tests for kubeconfig path resolution and discovery."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from fluxcd_k8s.kubeconfig import (
+    DEFAULT_SEARCH_DIRS,
+    KubeconfigNotFound,
+    expand_path,
+    get_search_dirs,
+    require_kubeconfig_path,
+    resolve_kubeconfig_path,
+    resolve_path_entry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(monkeypatch, tmp_path):
+    """Keep the host's real kubeconfig out of every test."""
+    monkeypatch.delenv("KUBECONFIG", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+
+
+def _write_kubeconfig(path):
+    """Create a placeholder kubeconfig file at path (parents included)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("apiVersion: v1\nkind: Config\n")
+    return str(path)
+
+
+class TestExpandPath:
+    def test_expands_home_shortcut(self, tmp_path):
+        assert expand_path("~/.kube/config") == str(tmp_path / "home" / ".kube" / "config")
+
+    def test_expands_environment_variable(self, monkeypatch):
+        monkeypatch.setenv("MY_KUBE_DIR", "/opt/kube")
+        assert expand_path("$MY_KUBE_DIR/config") == "/opt/kube/config"
+
+    def test_strips_surrounding_whitespace(self):
+        assert expand_path("  /config/kubeconfig  ") == "/config/kubeconfig"
+
+
+class TestResolvePathEntry:
+    def test_resolves_tilde_path_to_real_file(self, tmp_path):
+        expected = _write_kubeconfig(tmp_path / "home" / ".kube" / "config")
+        assert resolve_path_entry("~/.kube/config") == expected
+
+    def test_resolves_directory_to_contained_config(self, tmp_path):
+        expected = _write_kubeconfig(tmp_path / "home" / ".kube" / "config")
+        assert resolve_path_entry(str(tmp_path / "home" / ".kube")) == expected
+
+    def test_resolves_directory_to_contained_kubeconfig(self, tmp_path):
+        expected = _write_kubeconfig(tmp_path / "kubeconfig")
+        assert resolve_path_entry(str(tmp_path)) == expected
+
+    def test_resolves_directory_via_dot_kube_subdirectory(self, tmp_path):
+        expected = _write_kubeconfig(tmp_path / ".kube" / "config")
+        assert resolve_path_entry(str(tmp_path)) == expected
+
+    def test_returns_none_for_missing_path(self, tmp_path):
+        assert resolve_path_entry(str(tmp_path / "missing")) is None
+
+    def test_returns_none_for_empty_path(self):
+        assert resolve_path_entry("   ") is None
+
+
+class TestResolveKubeconfigPath:
+    def test_configured_file_wins(self, tmp_path):
+        expected = _write_kubeconfig(tmp_path / "custom" / "my-kubeconfig")
+        assert resolve_kubeconfig_path(expected, [str(tmp_path)]) == expected
+
+    def test_configured_tilde_path_is_expanded(self, tmp_path):
+        expected = _write_kubeconfig(tmp_path / "home" / ".kube" / "config")
+        assert resolve_kubeconfig_path("~/.kube/config", []) == expected
+
+    def test_missing_configured_path_returns_none(self, tmp_path):
+        assert resolve_kubeconfig_path(str(tmp_path / "nope"), []) is None
+
+    def test_multiple_configured_paths_are_joined(self, tmp_path):
+        first = _write_kubeconfig(tmp_path / "a" / "kubeconfig")
+        second = _write_kubeconfig(tmp_path / "b" / "kubeconfig")
+        combined = os.pathsep.join([first, second])
+        assert resolve_kubeconfig_path(combined, []) == combined
+
+    def test_missing_entry_in_list_is_skipped(self, tmp_path):
+        existing = _write_kubeconfig(tmp_path / "a" / "kubeconfig")
+        combined = os.pathsep.join([str(tmp_path / "gone"), existing])
+        assert resolve_kubeconfig_path(combined, []) == existing
+
+    def test_empty_path_finds_home_kube_config(self, tmp_path):
+        expected = _write_kubeconfig(tmp_path / "home" / ".kube" / "config")
+        assert resolve_kubeconfig_path("", get_search_dirs()) == expected
+
+    def test_empty_path_finds_config_dir_kubeconfig(self, tmp_path):
+        expected = _write_kubeconfig(tmp_path / "ha-config" / "kubeconfig")
+        search_dirs = get_search_dirs(str(tmp_path / "ha-config"))
+        assert resolve_kubeconfig_path("", search_dirs) == expected
+
+    def test_empty_path_finds_config_dir_dot_kube_config(self, tmp_path):
+        expected = _write_kubeconfig(tmp_path / "ha-config" / ".kube" / "config")
+        search_dirs = get_search_dirs(str(tmp_path / "ha-config"))
+        assert resolve_kubeconfig_path("", search_dirs) == expected
+
+    def test_empty_path_honors_kubeconfig_env_var(self, tmp_path, monkeypatch):
+        expected = _write_kubeconfig(tmp_path / "env" / "kubeconfig")
+        monkeypatch.setenv("KUBECONFIG", expected)
+        # A home kubeconfig also exists; KUBECONFIG must take precedence.
+        _write_kubeconfig(tmp_path / "home" / ".kube" / "config")
+        assert resolve_kubeconfig_path("", get_search_dirs()) == expected
+
+    def test_returns_none_when_nothing_exists(self, tmp_path):
+        assert resolve_kubeconfig_path("", [str(tmp_path / "nowhere")]) is None
+
+
+class TestGetSearchDirs:
+    def test_config_dir_is_searched_first(self):
+        dirs = get_search_dirs("/config")
+        assert dirs[0] == os.path.join("/config", ".kube")
+        assert dirs[1] == "/config"
+
+    def test_defaults_are_included(self):
+        dirs = get_search_dirs("/config")
+        for default_dir in DEFAULT_SEARCH_DIRS:
+            assert default_dir in dirs
+
+    def test_duplicates_are_removed(self):
+        dirs = get_search_dirs("/config")
+        assert len(dirs) == len(set(dirs))
+
+    def test_without_config_dir_returns_defaults(self):
+        assert get_search_dirs() == list(DEFAULT_SEARCH_DIRS)
+
+
+class TestRequireKubeconfigPath:
+    def test_returns_resolved_path(self, tmp_path):
+        expected = _write_kubeconfig(tmp_path / "home" / ".kube" / "config")
+        assert require_kubeconfig_path("~/.kube/config", []) == expected
+
+    def test_error_mentions_the_configured_path(self, tmp_path):
+        missing = str(tmp_path / "nope" / "kubeconfig")
+        with pytest.raises(KubeconfigNotFound, match="nope"):
+            require_kubeconfig_path(missing, [])
+
+    def test_error_lists_searched_directories(self, tmp_path):
+        with pytest.raises(KubeconfigNotFound, match="/config"):
+            require_kubeconfig_path("", ["/config", "~/.kube"])


### PR DESCRIPTION
## The bug

Entering `~/.kube/config` as the Kubeconfig Path failed setup. The config flow validated the path with `os.path.isfile("~/.kube/config")`, which is always `False` — `~` is only meaningful to a shell — so a valid path was rejected as missing and the kubeconfig was never read.

## The fix

New `custom_components/fluxcd_k8s/kubeconfig.py`, used by both the config flow (validation) and `api.py` (loading), so a path resolves the same way in both places:

- Expands `~` and environment variables before touching the filesystem
- Accepts a **directory** — searched for `config`, `kubeconfig`, `kubeconfig.yaml`, `kubeconfig.yml`, including inside a `.kube/` subdirectory
- Accepts a `:`-separated list of paths, the same syntax `KUBECONFIG` uses; missing entries are skipped like kubectl does
- **Empty path auto-discovers the file**, searching in this order: the `KUBECONFIG` environment variable, then the HA config directory (`/config/.kube/`, then `/config/`), then `~/.kube/`, `~/`, and `/root/.kube/`
- Raises `KubeconfigNotFound` naming the path or the directories searched, instead of failing later with a `NoneType` error out of `KubeConfigMerger`
- Also catches the "file found but empty/unparseable" case with a clear message

`api.py` re-resolves at load time rather than storing a resolved snapshot, so a moved file is picked up without reconfiguring the integration. The config entry still stores exactly what the user typed.

Error text and field help in `strings.json` / `translations/en.json` were updated to describe the accepted values and the search locations.

## Docs

Installation now comes first, as the user asked:

- Intro → table of contents → **Installation**
- Four numbered steps: install (HACS/manual) → choose cluster access → apply RBAC → add the integration
- Small tables instead of prose for requirements, access modes, accepted path values, and config fields
- A kubeconfig section covering where to put the file and why the HA config directory rather than `~` on HA OS/Container installs, plus the `exec:` credential-plugin caveat
- A troubleshooting table and a debug-logging snippet
- Reference material (features, resource types, attributes, Lovelace examples, how it works) moved below, unchanged; `Project Structure` moved to the end and gained the new module

## Testing

- 145 tests pass (`python3 -m pytest tests/`)
- New `tests/test_kubeconfig.py`: 23 tests covering tilde and env-var expansion, directory paths, `:`-separated lists, each discovery location, `KUBECONFIG` precedence, and both error messages
- Updated `tests/test_config_flow.py` and `tests/test_api.py` for the new resolution path, including an end-to-end `~/.kube/config` case that reproduces the reported bug
- `ruff check` clean on every file touched